### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cf start
 The project is released under version 2.0 of the [Apache License][].
 
 [Apache License]: http://www.apache.org/licenses/LICENSE-2.0
-[Cloud Foundry]: http://run.pivotal.io
-[cloud-foundry-account]: http://docs.cloudfoundry.com/docs/dotcom/getting-started.html#signup
-[installed the `cf` command line tool]: http://docs.cloudfoundry.com/docs/dotcom/getting-started.html#install-cf
+[Cloud Foundry]: https://run.pivotal.io
+[cloud-foundry-account]: https://docs.cloudfoundry.com/docs/dotcom/getting-started.html#signup
+[installed the `cf` command line tool]: https://docs.cloudfoundry.com/docs/dotcom/getting-started.html#install-cf
 [manifest]: manifest.yml


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://docs.cloudfoundry.com/docs/dotcom/getting-started.html (UnknownHostException) with 2 occurrences migrated to:  
  https://docs.cloudfoundry.com/docs/dotcom/getting-started.html ([https](https://docs.cloudfoundry.com/docs/dotcom/getting-started.html) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://run.pivotal.io with 1 occurrences migrated to:  
  https://run.pivotal.io ([https](https://run.pivotal.io) result 200).